### PR TITLE
NFT mint contract copy

### DIFF
--- a/apps/enterprise/src/pages/create-dao/nft/NftAddressInput.tsx
+++ b/apps/enterprise/src/pages/create-dao/nft/NftAddressInput.tsx
@@ -10,7 +10,7 @@ export const NftAddressInput = () => {
   return (
     <WizardInput
       label="NFT address"
-      placeholder="Type your existing CW721 NFT address"
+      placeholder="Type your existing CW721 NFT contract address"
       value={existingNFTAddr}
       error={existingNFTError}
       valid={existingNFT !== undefined}

--- a/apps/enterprise/src/pages/create-dao/nft/NftMembershipStep.tsx
+++ b/apps/enterprise/src/pages/create-dao/nft/NftMembershipStep.tsx
@@ -31,8 +31,8 @@ export function NftMembershipStep() {
           onChange={({ currentTarget }) => onChange({ nftSymbol: currentTarget.value })}
         />
         <WizardInput
-          label="NFT Minter"
-          placeholder="Minter Terra address"
+          label="NFT Mint Contract"
+          placeholder="Terra contract address"
           value={nftMembership.minter}
           error={nftMembership.minterError}
           onChange={({ currentTarget }) => onChange({ minter: currentTarget.value })}


### PR DESCRIPTION
Update the app copy to clarify that this needs to be the address of the NFT mint contract. Users are getting confused and putting in their own addresses. 