### PR TITLE
Fix/naming convention changes

### DIFF
--- a/apps/enterprise/src/App.tsx
+++ b/apps/enterprise/src/App.tsx
@@ -96,7 +96,7 @@ const AppBetaRoutes = () => {
             }
           />
           <Route
-            path="distribute"
+            path="rewards"
             element={
               <InitizalizedWalletOnly>
                 <DaoErrorBoundary>

--- a/apps/enterprise/src/pages/dao/DaoNavigation/index.tsx
+++ b/apps/enterprise/src/pages/dao/DaoNavigation/index.tsx
@@ -11,7 +11,7 @@ const daoViewName: Record<DaoView, string> = {
   overview: 'Overview',
   treasury: 'Treasury',
   proposals: 'Proposals',
-  distribute: 'Distribute',
+  distribute: 'Rewards',
   staking: 'Staking',
   members: 'Members',
 };
@@ -20,7 +20,7 @@ const daoViewPath: Record<DaoView, string> = {
   overview: '',
   treasury: 'treasury',
   proposals: 'proposals',
-  distribute: 'distribute',
+  distribute: 'rewards',
   staking: 'staking',
   members: 'members',
 };

--- a/apps/enterprise/src/pages/dao/distribute/deposit/index.tsx
+++ b/apps/enterprise/src/pages/dao/distribute/deposit/index.tsx
@@ -15,11 +15,11 @@ export const DepositIntoFundsDistributor = () => {
   const shareholders = isMultisig ? 'multisig members' : 'stakers'
 
   return (
-    <TitledSection title={`Distribute between ${shareholders}`}>
+    <TitledSection title={`Distribute rewards to your ${shareholders}`}>
       <VStack gap={8}>
 
         <Text color="supporting">
-          Deposit an asset to the fund's distributor contract to distribute it to DAO {shareholders} to claim.
+          Assets deposited will be distributed as rewards for DAO {shareholders} to claim.
         </Text>
         <OverlayOpener
           renderOpener={({ onOpen }) => (

--- a/apps/enterprise/src/pages/dao/staking/NFTStaking.tsx
+++ b/apps/enterprise/src/pages/dao/staking/NFTStaking.tsx
@@ -130,7 +130,7 @@ export const NftStakingConnectedView = () => {
         <VStack gap={16}>
           <NumericPanel
             className={styles.claim}
-            title="Claimable NFTs"
+            title="Claim Unstaked NFTs"
             value={claimableTokens.length}
             suffix={symbol}
             footnote={

--- a/apps/enterprise/src/pages/dao/staking/TokenStaking.tsx
+++ b/apps/enterprise/src/pages/dao/staking/TokenStaking.tsx
@@ -181,7 +181,7 @@ export const TokenStakingConnectedView = () => {
         <VStack gap={16}>
           <NumericPanel
             className={styles.claim}
-            title="Claimable tokens"
+            title="Claim Unstaked Tokens"
             value={demicrofy(claimableAmount, tokenDecimals)}
             decimals={2}
             suffix={tokenSymbol}


### PR DESCRIPTION
- Renamed distribute to rewards
- Renamed claimable nft/tokens to claim unstaked nfts/tokens