### PR TITLE
fix wasm log indexing

### DIFF
--- a/indexers/shared/collectors/events/groupAttributes.ts
+++ b/indexers/shared/collectors/events/groupAttributes.ts
@@ -1,15 +1,45 @@
-import { Attribute } from "../../services/block-listener";
+import { Attribute } from '../../services/block-listener';
 
-export const groupAttributes = (
-  attributes: Array<Attribute>
-): Array<Array<Attribute>> => {
-  return attributes.reduce((previous, current) => {
-    if (current.key === "_contract_address") {
-      previous.push([]);
+export const groupAttributes = (attributes: Array<Attribute>): Array<Array<Attribute>> => {
+  // Step 1: Create groups delimited by _contract_address
+  let groups: Array<Array<Attribute>> = [];
+  let currentGroup: Array<Attribute> = [];
+
+  attributes.forEach((attribute) => {
+    if (attribute.key === '_contract_address') {
+      if (currentGroup.length > 0) {
+        groups.push(currentGroup);
+      }
+      currentGroup = [attribute];
+    } else {
+      currentGroup.push(attribute);
     }
-    if (previous.length > 0) {
-      previous[previous.length - 1].push(current);
+  });
+
+  if (currentGroup.length > 0) {
+    groups.push(currentGroup);
+  }
+
+  // Step 2: Merge groups that have the same _contract_address
+  let result: Array<Array<Attribute>> = [];
+  let groupMap: { [key: string]: Array<Attribute> } = {};
+
+  groups.forEach((group) => {
+    let contractAddress = group.find((attribute) => attribute.key === '_contract_address')?.value;
+    if (contractAddress) {
+      if (!groupMap[contractAddress]) {
+        groupMap[contractAddress] = [];
+      }
+      group.forEach((attribute) => {
+        if (attribute.key !== '_contract_address' || groupMap[contractAddress].length === 0) {
+          groupMap[contractAddress].push(attribute);
+        }
+      });
     }
-    return previous;
-  }, []);
+  });
+
+  Object.values(groupMap).forEach((group) => {
+    result.push(group);
+  });
+  return result;
 };


### PR DESCRIPTION
This pull request is attempting to fix issue with incorrect grouping of wasm events in case when the events attributes are not continuously grouped together in the wasm log.
```[
  {
    key: '_contract_address',
    value: 'terra1e7h6yy2zawzn06tg5l0xp3gv4pwj0y6lf69xvcncnlttsfngx2hscqgrdy'
  },
  { key: 'action', value: 'create_proposal' },
  {
    key: 'dao_address',
    value: 'terra1e7h6yy2zawzn06tg5l0xp3gv4pwj0y6lf69xvcncnlttsfngx2hscqgrdy'
  },
  {
    key: '_contract_address',
    value: 'terra1gll4efpjwn5hh6kngkpscsf7kydplmfn554p9an5jm6gfjuxc2msdazz00'
  },
  { key: 'action', value: 'create_poll' },
  { key: 'poll_id', value: '2' },
  { key: 'proposal_id', value: '2' },
  {
    key: '_contract_address',
    value: 'terra1e7h6yy2zawzn06tg5l0xp3gv4pwj0y6lf69xvcncnlttsfngx2hscqgrdy'
  },
  { key: 'proposal_id', value: '2' }
]

```
transforming into
```
[
  [
    {
      key: '_contract_address',
      value: 'terra1e7h6yy2zawzn06tg5l0xp3gv4pwj0y6lf69xvcncnlttsfngx2hscqgrdy'
    },
    { key: 'action', value: 'create_proposal' },
    {
      key: 'dao_address',
      value: 'terra1e7h6yy2zawzn06tg5l0xp3gv4pwj0y6lf69xvcncnlttsfngx2hscqgrdy'
    },
    { key: 'proposal_id', value: '2' }
  ],
  [
    {
      key: '_contract_address',
      value: 'terra1gll4efpjwn5hh6kngkpscsf7kydplmfn554p9an5jm6gfjuxc2msdazz00'
    },
    { key: 'action', value: 'create_poll' },
    { key: 'poll_id', value: '2' },
    { key: 'proposal_id', value: '2' }
  ]
]
```
The code is relying on assumption that attributes that "go together" are grouped under same _contract_address. 

