### PR TITLE
add check test for err.response is defined

### DIFF
--- a/indexers/shared/services/block-listener/BlockListener.ts
+++ b/indexers/shared/services/block-listener/BlockListener.ts
@@ -52,7 +52,7 @@ export class BlockListener {
 
         return [blockInfo, txs];
       } catch (err) {
-        if (axios.isAxiosError(err) && err.response.status === 400) {
+        if (axios.isAxiosError(err) && err.response && err.response.status === 400) {
           // likely the block doesn't exist so we skip writing this as an error
           await sleep(1000);
           continue;


### PR DESCRIPTION
During today's core upgrade to 2.3.4 I noticed that the events indexer has restarted multiple times.

```
[ec2-user@ph1-ecs-use1-az4 ~]$ docker ps -a | grep enterprise-events | grep idx
6663b0c10b6d   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   26 minutes ago   Exited (0) 26 minutes ago               ecs-enterprise-events-12-enterprise-d696c9b79aa1b38f3200
aa64f34651f1   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   37 minutes ago   Exited (0) 37 minutes ago               ecs-enterprise-events-12-enterprise-8ef8c1b3c8f8fcc8ef01
ffc4740dbe4f   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   37 minutes ago   Exited (0) 37 minutes ago               ecs-enterprise-events-12-enterprise-e2eed786c3d6a6bc6500
32b545c8bc4d   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   45 minutes ago   Exited (0) 45 minutes ago               ecs-enterprise-events-12-enterprise-96b39cc8e4cfbafb6800
054dc321db5c   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   46 minutes ago   Exited (0) 46 minutes ago               ecs-enterprise-events-12-enterprise-aae39cedbcd7ded12900
47f8b8c59580   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   31 hours ago     Exited (0) 46 minutes ago               ecs-enterprise-events-12-enterprise-8ca1f9f99ba6d7f73b00
[ec2-user@
[ec2-user@ph1-ecs-use1-az2 ~]$ docker ps -a | grep enterprise-events | grep idx
e240660cd2d9   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   26 minutes ago      Exited (0) 26 minutes ago                ecs-enterprise-events-12-enterprise-c4d5e68286b78db61800
846fbda72b4d   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   27 minutes ago      Exited (0) 27 minutes ago                ecs-enterprise-events-12-enterprise-84fa8698d185e4e28f01
d200f15c852b   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   27 minutes ago      Exited (0) 27 minutes ago                ecs-enterprise-events-12-enterprise-bea6d3aecc82a8b22300
f094477847d7   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   36 minutes ago      Exited (0) 36 minutes ago                ecs-enterprise-events-12-enterprise-c4b395b7a4d296dd6e00
eaa7d119b8cd   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx      "node ./collectors/e…"   45 minutes ago      Exited (0) 45 minutes ago                ecs-enterprise-events-12-enterprise-a290dde6d9f3f9aa0c00
[ec2-user@ph1-ecs-use1-az2 ~]$

[ec2-user@ph1-ecs-use1-az6 ~]$ docker ps -a | grep enterprise-events | grep idx
0d2231697b72   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx             "node ./collectors/e…"   26 minutes ago      Up 26 minutes                            ecs-enterprise-events-12-enterprise-b2b686ef90ccfc380000
bfeba671bc29   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx             "node ./collectors/e…"   26 minutes ago      Exited (0) 26 minutes ago                ecs-enterprise-events-12-enterprise-8a819bf2d6aedda2e101
502a6a85c0d8   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx             "node ./collectors/e…"   36 minutes ago      Exited (0) 28 minutes ago                ecs-enterprise-events-12-enterprise-eca0c6faa2eb87ff7e00
c99af6f0a61c   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx             "node ./collectors/e…"   36 minutes ago      Exited (0) 36 minutes ago                ecs-enterprise-events-12-enterprise-dadbf3d2d0d4eb896e00
a15b45b2659b   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx             "node ./collectors/e…"   45 minutes ago      Exited (0) 37 minutes ago                ecs-enterprise-events-12-enterprise-cea6828e82bcecb1c601
15c1e8bb9135   616478479272.dkr.ecr.us-east-1.amazonaws.com/enterprise-idx             "node ./collectors/e…"   45 minutes ago      Exited (0) 45 minutes ago                ecs-enterprise-events-12-enterprise-bcc8ec95d382dfbe2700
[ec2-user@ph1-ecs-use1-az6 ~]$
```
Upon brief investigation i found that it was restarted due to 

`"msg":"[Runner] TypeError: Cannot read properties of undefined (reading 'status')"}`

Added check makes sure that the err.response is defined and events indexer works as expected on rpc failure/restart.

```
{"level":30,"time":1686336113315,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4742"}
{"level":30,"time":1686336113322,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4743"}
{"level":30,"time":1686336113330,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4744"}
{"level":30,"time":1686336113344,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4745"}
{"level":50,"time":1686336113348,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 502\""}
{"level":50,"time":1686336114351,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"Error: connect ECONNREFUSED 127.0.0.1:1317\""}
{"level":50,"time":1686336115355,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"Error: socket hang up\""}
{"level":50,"time":1686336116358,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 502\""}
{"level":50,"time":1686336117361,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 503\""}
{"level":50,"time":1686336118365,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 503\""}
{"level":50,"time":1686336119369,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 503\""}
{"level":50,"time":1686336120372,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 503\""}
{"level":50,"time":1686336121377,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 503\""}
{"level":50,"time":1686336122383,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Error waiting for block 4745 \"AxiosError: Request failed with status code 503\""}
{"level":30,"time":1686336123392,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4746"}
{"level":30,"time":1686336123398,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4747"}
{"level":30,"time":1686336123405,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4748"}
{"level":30,"time":1686336123413,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4749"}
{"level":30,"time":1686336123422,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4750"}
{"level":30,"time":1686336123430,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4751"}
{"level":30,"time":1686336123437,"pid":28153,"hostname":"DESKTOP-N525ALJ","msg":"[BlockListener] Process block with height=4752"}
```